### PR TITLE
Using get_feature_names method to extract feature names from DictVectorizer

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -1,4 +1,5 @@
 import sys
+import inspect
 import pandas as pd
 import numpy as np
 from scipy import sparse
@@ -30,6 +31,19 @@ def _build_transformer(transformers):
 def _build_feature(columns, transformers, options={}):
     return (columns, _build_transformer(transformers), options)
 
+
+def _get_feature_names(estimator):
+    """
+    Attempt to extract feature names based on a given estimator.
+    Note: this might break some of the existing pipeline as there might be
+    actual names instead of _0, _1, ...
+    """
+    if hasattr(estimator, 'classes_'):
+        return estimator.classes_
+    elif hasattr(estimator, 'get_feature_names') \
+            and inspect.ismethod(getattr(estimator, 'get_feature_names')):
+        return estimator.get_feature_names()
+    return None
 
 class DataFrameMapper(BaseEstimator, TransformerMixin):
     """
@@ -193,9 +207,9 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         if num_cols > 1:
             # If there are as many columns as classes in the transformer,
             # infer column names from classes names.
-            if hasattr(transformer, 'classes_') and \
-                    (len(transformer.classes_) == num_cols):
-                return [name + '_' + str(o) for o in transformer.classes_]
+            names = _get_feature_names(transformer)
+            if names is not None and len(names) == num_cols:
+                return [name + '_' + str(o) for o in names]
             # otherwise, return name concatenated with '_1', '_2', etc.
             else:
                 return [name + '_' + str(o) for o in range(num_cols)]

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -17,6 +17,7 @@ from sklearn.datasets import load_iris
 from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC
 from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.feature_extraction import DictVectorizer
 from sklearn.preprocessing import (
     Imputer, StandardScaler, OneHotEncoder, LabelBinarizer)
 from sklearn.feature_selection import SelectKBest, chi2
@@ -641,6 +642,24 @@ def test_with_iris_dataframe(iris_dataframe):
     scores = cross_val_score(pipeline, data, labels)
     assert scores.mean() > 0.96
     assert (scores.std() * 2) < 0.04
+
+
+def test_dict_vectorizer():
+    df = pd.DataFrame(
+        [[{'a': 1, 'b': 2}], [{'a': 3}]],
+        columns=['colA']
+    )
+
+    outdf = DataFrameMapper(
+        [('colA', DictVectorizer())],
+        df_out=True,
+        default=False
+    ).fit_transform(df)
+
+    columns =  sorted(list(outdf.columns))
+    assert len(columns) == 2
+    assert columns[0] == 'colA_a'
+    assert columns[1] == 'colA_b'
 
 
 def test_with_car_dataframe(cars_dataframe):


### PR DESCRIPTION
Existing code fails to get feature names if using DictVectorizer as it doesn't have classes_ attribute. Instead, it has get_feature_names. This pull requests separate out the logic of extracting feature names into a separate method and first attempts to extract feature names using classes_ attribute and then uses get_feature_names. Otherwise it returns None. 