### PR TITLE
Use lineage for names

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -137,6 +137,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         self.df_out = state.get('df_out', False)
 
         self.input_df = state.get('input_df', False)
+        self.use_lineage_for_names = state.get('use_lineage_for_names', False)
 
     def _get_col_subset(self, X, cols):
         """

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -1,4 +1,5 @@
 import sys
+import inspect
 import pandas as pd
 import numpy as np
 from scipy import sparse
@@ -30,6 +31,19 @@ def _build_transformer(transformers):
 def _build_feature(columns, transformers, options={}):
     return (columns, _build_transformer(transformers), options)
 
+
+def _get_feature_names(estimator):
+    """
+    Attempt to extract feature names based on a given estimator.
+    Note: this might break some of the existing pipeline as there might be
+    actual names instead of _0, _1, ...
+    """
+    if hasattr(estimator, 'classes_'):
+        return estimator.classes_
+    elif hasattr(estimator, 'get_feature_names') \
+            and inspect.ismethod(getattr(estimator, 'get_feature_names')):
+        return estimator.get_feature_names()
+    return None
 
 class DataFrameMapper(BaseEstimator, TransformerMixin):
     """
@@ -193,9 +207,9 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         if num_cols > 1:
             # If there are as many columns as classes in the transformer,
             # infer column names from classes names.
-            if hasattr(transformer, 'classes_') and \
-                    (len(transformer.classes_) == num_cols):
-                return [name + '_' + str(o) for o in transformer.classes_]
+            names = _get_feature_names(transformer)
+            if names is not None and len(names) == num_cols:
+                return [name + '_' + str(o) for o in names]
             # otherwise, return name concatenated with '_1', '_2', etc.
             else:
                 return [name + '_' + str(o) for o in range(num_cols)]

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -45,6 +45,7 @@ def _get_feature_names(estimator):
         return estimator.get_feature_names()
     return None
 
+
 class DataFrameMapper(BaseEstimator, TransformerMixin):
     """
     Map Pandas data frame column subsets to their own
@@ -84,6 +85,9 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         input_df    If ``True`` pass the selected columns to the transformers
                     as a pandas DataFrame or Series. Otherwise pass them as a
                     numpy array. Defaults to ``False``.
+
+        use_lineage_for_names   if ``True``, try to extract feature name from
+                                previous estimators in the pipeline.
         """
         if isinstance(features, list):
             features = [_build_feature(*feature) for feature in features]
@@ -199,7 +203,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         x             transformed columns (numpy.ndarray)
         alias         base name to use for the selected columns
         use_lineage_for_names         try to extract feature names from
-        previous estimators in the pipeline. 
+        previous estimators in the pipeline.
         """
         if alias is not None:
             name = alias
@@ -216,14 +220,16 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
             # try to extract feature names from other estimators
             # this happens only if use_lineage_for_name is enabled
             if names is None and use_lineage_for_name:
-                for (estimator_name, estimator) in transformer.steps[0:-1][::-2]:
+                for (estimator_name, estimator) in \
+                        transformer.steps[0:-1][::-2]:
                     feature_names = _get_feature_names(estimator)
-                    if names is not None and len(names) == num_cols:
+                    if feature_names is not None \
+                            and len(feature_names) == num_cols:
                         names = feature_names
                         break
 
             if names is not None:
-                return [name + '_' + o for o in range(names)]
+                return [name + '_' + str(o) for o in names]
             else:
                 return [name + '_' + str(o) for o in range(num_cols)]
         else:

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -17,6 +17,7 @@ from sklearn.datasets import load_iris
 from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC
 from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.feature_extraction import DictVectorizer
 from sklearn.preprocessing import (
     Imputer, StandardScaler, OneHotEncoder, LabelBinarizer)
 from sklearn.feature_selection import SelectKBest, chi2
@@ -641,6 +642,24 @@ def test_with_iris_dataframe(iris_dataframe):
     scores = cross_val_score(pipeline, data, labels)
     assert scores.mean() > 0.96
     assert (scores.std() * 2) < 0.04
+
+
+def test_dict_vectorizer():
+    df = pd.DataFrame(
+        [[{'a': 1, 'b': 2}], [{'a': 3}]],
+        columns=['colA']
+    )
+
+    outdf = DataFrameMapper(
+        [('colA', DictVectorizer())],
+        df_out=True,
+        default=False
+    ).fit_transform(df)
+
+    columns =  sorted(list(outdf.columns))
+    assert len(columns) == 2
+    assert columns[0] == 'colA_a'
+    assert columns[1] == 'colA_b'
 
 
 def test_with_car_dataframe(cars_dataframe):


### PR DESCRIPTION
If there are multiple transformers, existing code uses only the last transformer to fetch feature names. Adding a global and local option "use_lineage_for_names" to extract transformed column names based on other transformers in the pipeline. 