### PR TITLE
Do not mutate features in __init__.

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -71,9 +71,8 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                     as a pandas DataFrame or Series. Otherwise pass them as a
                     numpy array. Defaults to ``False``.
         """
-        if isinstance(features, list):
-            features = [_build_feature(*feature) for feature in features]
         self.features = features
+        self.built_features = None
         self.default = _build_transformer(default)
         self.sparse = sparse
         self.df_out = df_out
@@ -163,7 +162,12 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         y       the target vector relative to X, optional
 
         """
-        for columns, transformers, options in self.features:
+        if isinstance(self.features, list):
+            self.built_features = [_build_feature(*_f) for _f in self.features]
+        else:
+            self.built_features = self.features
+
+        for columns, transformers, options in self.built_features:
             if transformers is not None:
                 _call_fit(transformers.fit,
                           self._get_col_subset(X, columns), y)
@@ -210,7 +214,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         """
         extracted = []
         self.transformed_names_ = []
-        for columns, transformers, options in self.features:
+        for columns, transformers, options in self.built_features:
             # columns could be a string or list of
             # strings; we don't care because pandas
             # will handle either.


### PR DESCRIPTION
Taking a stab at pandas-dev/sklearn-pandas#76.


Before:
```
$ python -m doctest README.rst
/home/vagrant/.pyenv/versions/miniconda3-4.1.11/envs/sklearn-pandas/lib/python3.6/site-packages/sklearn/utils/validation.py:429: DataConversionWarning: Data with input dtype int64 was converted to float64 by StandardScaler.
  warnings.warn(msg, _DataConversionWarning)
/home/vagrant/.pyenv/versions/miniconda3-4.1.11/envs/sklearn-pandas/lib/python3.6/site-packages/sklearn/base.py:122: DeprecationWarning: Estimator DataFrameMapper modifies parameters in __init__. This behavior is deprecated as of 0.18 and support for this behavior will be removed in 0.20.
  % type(estimator).__name__, DeprecationWarning)
/home/vagrant/.pyenv/versions/miniconda3-4.1.11/envs/sklearn-pandas/lib/python3.6/site-packages/sklearn/base.py:122: DeprecationWarning: Estimator DataFrameMapper modifies parameters in __init__. This behavior is deprecated as of 0.18 and support for this behavior will be removed in 0.20.
  % type(estimator).__name__, DeprecationWarning)
/home/vagrant/.pyenv/versions/miniconda3-4.1.11/envs/sklearn-pandas/lib/python3.6/site-packages/sklearn/base.py:122: DeprecationWarning: Estimator DataFrameMapper modifies parameters in __init__. This behavior is deprecated as of 0.18 and support for this behavior will be removed in 0.20.
  % type(estimator).__name__, DeprecationWarning)
```

After:
```
$ python -m doctest README.rst
/home/vagrant/.pyenv/versions/miniconda3-4.1.11/envs/sklearn-pandas/lib/python3.6/site-packages/sklearn/utils/validation.py:429: DataConversionWarning: Data with input dtype int64 was converted to float64 by StandardScaler.
  warnings.warn(msg, _DataConversionWarning)
```