### PR TITLE
Add column name to exception during fit/transform

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,11 @@ Example:
 Changelog
 ---------
 
+Development
+***********
+* Add column name to exception during fit/transform (#110).
+
+
 1.5.0 (2017-06-24)
 ******************
 * Allow inputting a dataframe/series per group of columns.

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -163,6 +163,42 @@ def test_transformed_names_complex_alias(complex_dataframe):
     assert mapper.transformed_names_ == ['new_a', 'new_b', 'new_c']
 
 
+def test_exception_column_context_transform(simple_dataframe):
+    """
+    If an exception is raised when transforming a column,
+    the exception includes the name of the column being transformed
+    """
+    class FailingTransformer(object):
+        def fit(self, X):
+            pass
+
+        def transform(self, X):
+            raise Exception('Some exception')
+
+    df = simple_dataframe
+    mapper = DataFrameMapper([('a', FailingTransformer())])
+    mapper.fit(df)
+
+    with pytest.raises(Exception, match='a: Some exception'):
+        mapper.transform(df)
+
+
+def test_exception_column_context_fit(simple_dataframe):
+    """
+    If an exception is raised when fit a column,
+    the exception includes the name of the column being fitted
+    """
+    class FailingFitter(object):
+        def fit(self, X):
+            raise Exception('Some exception')
+
+    df = simple_dataframe
+    mapper = DataFrameMapper([('a', FailingFitter())])
+
+    with pytest.raises(Exception, match='a: Some exception'):
+        mapper.fit(df)
+
+
 def test_simple_df(simple_dataframe):
     """
     Get a dataframe from a simple mapped dataframe

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = {py27,py35}-sklearn{17,18}
 
 [testenv]
 deps =
-    pytest==3.0.5
+    pytest==3.2.1
     setuptools==16.0
     wheel==0.24.0
     flake8==2.4.1


### PR DESCRIPTION
This can help debugging a lot, since otherwise it can be very hard to know which column transformation is failing from just the original error message.

Resolves https://github.com/pandas-dev/sklearn-pandas/issues/110.