### PR TITLE
Fix #95 preserve index of input dataframe

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -292,4 +292,5 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
             return stacked
         else:
             index = X.index if self.input_df else None
-            return pd.DataFrame(stacked, columns=self.transformed_names_, index=index)
+            return pd.DataFrame(
+                    stacked, columns=self.transformed_names_, index=index)

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -288,9 +288,17 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         else:
             stacked = np.hstack(extracted)
 
-        if not self.df_out:
-            return stacked
+        if self.df_out:
+            # if no rows were dropped preserve the original index,
+            # otherwise use a new integer one
+            no_rows_dropped = len(X) == len(stacked)
+            if no_rows_dropped:
+                index = X.index
+            else:
+                index = None
+
+            return pd.DataFrame(stacked,
+                                columns=self.transformed_names_,
+                                index=index)
         else:
-            index = X.index if self.input_df else None
-            return pd.DataFrame(
-                    stacked, columns=self.transformed_names_, index=index)
+            return stacked

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -290,5 +290,6 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
 
         if not self.df_out:
             return stacked
-
-        return pd.DataFrame(stacked, columns=self.transformed_names_)
+        else:
+            index = X.index if self.input_df else None
+            return pd.DataFrame(stacked, columns=self.transformed_names_, index=index)

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -82,7 +82,6 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                     as a pandas DataFrame or Series. Otherwise pass them as a
                     numpy array. Defaults to ``False``.
         """
-        # self.features_def = features
         self.features = features
         self.built_features = None
         self.default = default
@@ -176,11 +175,6 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         y       the target vector relative to X, optional
 
         """
-        # if isinstance(self.features_def, list):
-        #     self.features = [_build_feature(*f) for f in self.features_def]
-        # else:
-        #     self.features = self.features_def
-
         if isinstance(self.features, list):
             self.built_features = [_build_feature(*f) for f in self.features]
         else:

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -255,6 +255,42 @@ def test_customtransform_df():
     assert cols[0] == 'target'
 
 
+def test_preserve_df_index():
+    """
+    The index is preserved when df_out=True
+    """
+    df = pd.DataFrame({'target': [1, 2, 3]},
+                      index=['a', 'b', 'c'])
+    mapper = DataFrameMapper([('target', None)],
+                             df_out=True)
+
+    transformed = mapper.fit_transform(df)
+
+    assert_array_equal(transformed.index, df.index)
+
+
+def test_preserve_df_index_rows_dropped():
+    """
+    If df_out=True but the original df index length doesn't
+    match the number of final rows, use a numeric index
+    """
+    class DropLastRowTransformer(object):
+        def fit(self, X):
+            return self
+
+        def transform(self, X):
+            return X[:-1]
+
+    df = pd.DataFrame({'target': [1, 2, 3]},
+                      index=['a', 'b', 'c'])
+    mapper = DataFrameMapper([('target', DropLastRowTransformer())],
+                             df_out=True)
+
+    transformed = mapper.fit_transform(df)
+
+    assert_array_equal(transformed.index, np.array([0, 1]))
+
+
 def test_pca(complex_dataframe):
     """
     Check multi in and out with PCA


### PR DESCRIPTION
Fix #95 

If I understand the code correctly, the type of the output is handled in `DataFrameMapper.transform`. It only needs to pass the original index of the input dataframe before retuning the output. So what this patch does is just adding 2 lines at the end of `DataFrameMapper.transform`:
```Python
        if not self.df_out:
            return stacked
        else:
            index = X.index if self.input_df else None
            return pd.DataFrame(stacked, columns=self.transformed_names_, index=index)
```

It assumes that there is an index to preserve only when `self.input_df` is True, otherwise it passes `None` to `pd.DataFrame`, letting it generate an interger index.

Something I am not sure:
- If transformers that drop rows are allowed, it will need more hacks to track which rows are dropped
- `input_df` is allowed to specifiy per group of columns, while this patch only test the instance-wide flag `self.input_df`. It somehow forces the user the specify this when initiating the mapper. Maybe it is possible to make finer control by traversing the `options` of `self.built_features`. But this trick introduces a little bit complexity. Is it worth it?
- As for tests, I notice that the two functions ` test_simple_df` and ` test_complex_df` seem to be used to test df output. I think the index test should also be put in them, since they are both related to outputing a dataframe. But this involves modifying the fixtures, since the current fixtures only contain a trival integer index. Or should I just a new test case to avoid too much change?